### PR TITLE
Add minimal Dockerfile for building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:22.04 as build
+
+LABEL org.opencontainers.image.authors="Santiago <san@san.com>"
+LABEL org.opencontainers.image.source="https://github.com/santaclose/ssbd"
+
+# hadolint ignore=DL3008
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        binutils-mips-linux-gnu \
+        build-essential \
+        clang \
+        # FIXME: overkill
+        gcc-multilib \
+        git \
+        libcapstone-dev \
+        # NOTE: used by viewText.sh
+        nano \
+        # FIXME: just call python3
+        python-is-python3 \
+        python3 \
+        python3-pip \
+        # NOTE: used by toP64format.sh
+        xxd \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /src \
+    && git config --global --add safe.directory "*"
+
+WORKDIR /src
+
+ENV PATH="/src/tools:${PATH}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  build:
+    container_name: santaclose-ssbd-build
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: build
+    volumes:
+      - ./:/src


### PR DESCRIPTION
This adds a minimal Docker setup to help make building a bit more portable.

Right now, it's still a bit of work to build, but this just focused on adding new files so it wouldn't interfere with anything you're currently doing. I also didn't want to put these instructions in the `README.md` because most of it will be removed with a little more work.

To build (assumes some Linux with `docker` + `git` installed):
```# preparation
git clone https://github.com/santaclose/ssbd ssbd
cd ssbd
cp $BASEROM ./baserom.z64

# on host
docker compose build build
docker compose run build bash

# in container
git submodule update --init --recursive
pip install -r tools/splat/requirements.txt
./installDependencies.sh
make extract
make
```